### PR TITLE
Ajuste de rota de redirect

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -11,6 +11,6 @@ server {
     }
 
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
     }
 }


### PR DESCRIPTION
O problema estava no `try_files $uri $uri/ /index.html;`


Quando o acesso ia para `/aposentadorias-pensoes`, o nginx tenta na ordem:

$uri -> procura o arquivo `/usr/share/nginx/html/aposentadorias-pensoes` -> não existe
$uri/ -> tenta tratar como diretório `/usr/share/nginx/html/aposentadorias-pensoes/` -> problema!
Quando o nginx tenta resolver como diretório e a URL não tem barra no final, ele emite um 301 redirect adicionando a `/` para "normalizar" a URL.


------------------------------------------------------------------------

Sobre o `port_in_redirect off;`

A aplicação roda internamente na porta 8080 (dentro do container), mas é exposta na porta 80 (pelo Docker/proxy).
Quando o nginx gerava um redirect, ele montava a URL de destino com a porta interna:
301 -> http://localhost:8080/aposentadorias-pensoes/

O browser recebia essa URL com :8080, que não é acessível de fora do container, então a navegação quebrava (se você manualmente alterasse a porta, funcionaria normal).

Quando navegava pelo index, o Angular Router assumia o controle e trocava as rotas client-side, sem fazer request HTTP nenhum ao nginx. Por isso não passava pelo redirect e funcionava.

Mas ao acessar `/aposentadorias-pensoes `diretamente na URL, o browser fazia um request real ao nginx, que gerava o 301 com :8080 na URL e quebrava.

